### PR TITLE
:sparkles: feat: 래퍼런스 저장 기능 추가

### DIFF
--- a/moamoa/build.gradle
+++ b/moamoa/build.gradle
@@ -39,6 +39,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 
+	implementation 'com.amazonaws:aws-java-sdk-s3:1.12.112'  // AWS S3 SDK 의존성 추가
+
 }
 tasks.named('test') {
 	useJUnitPlatform()

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/exception/FolderErrorCode.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/exception/FolderErrorCode.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum FolderErrorCode implements BaseResponseCode {
     FOLDER_USER_NOT_FOUND_404("FOLDER_USER_NOT_FOUND_404",404,"해당 사용자를 찾을 수 없습니다."),
-    FOLDER_NOT_FOUND_404("FOLDER_NOT_FOUND_404", 404, "해당 폴더를 찾을 수 없습니다.");
+    FOLDER_NOT_FOUND_404("FOLDER_NOT_FOUND_404", 404, "해당 폴더를 찾을 수 없습니다."),
     FOLDER_DUPLICATE_409("FOLDER_DUPLICATE_409",409,"이미 존재하는 폴더입니다.");
 
     private final String code;

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/controller/FolderController.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/controller/FolderController.java
@@ -12,7 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/user/{userId}/folders")
+@RequestMapping("/user/{userId}/folder")
 @RequiredArgsConstructor
 public class FolderController {
     // 의존성 부여

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/Config/S3Config.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/Config/S3Config.java
@@ -1,0 +1,28 @@
+package com.likelion.moamoa.domain.reference.Config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials awsCredentials= new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentials))
+                .build();
+    }
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
@@ -1,0 +1,33 @@
+package com.likelion.moamoa.domain.reference.entity;
+
+import com.likelion.moamoa.domain.auth.entity.User;
+import com.likelion.moamoa.domain.folder.entity.Folder;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+public class Reference {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "REFERENCE_ID")
+    private Long id;
+
+    @Column(name = "NAME")
+    private String name;
+
+    @Column(name = "DESCRIPTION")
+    private String description;
+
+    @Column(name = "IMG_URL")
+    private String imgUrl;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "FOLDER_ID", nullable = false)
+    private Folder folder;
+
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/repository/ReferenceRepository.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/repository/ReferenceRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.moamoa.domain.reference.repository;
+
+import com.likelion.moamoa.domain.reference.entity.Reference;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReferenceRepository extends JpaRepository<Reference, Long> {
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageService.java
@@ -1,0 +1,8 @@
+package com.likelion.moamoa.domain.reference.service;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public interface ImageService {
+    // s3에 저장하여 이미지 주소로 반환
+    String uploadImageToS3(MultipartFile img);
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageServiceImpl.java
@@ -1,0 +1,45 @@
+package com.likelion.moamoa.domain.reference.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+public class ImageServiceImpl implements ImageService {
+
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Override
+    public String uploadImageToS3(MultipartFile img) {
+        try {
+            // 파일 이름
+            String imgName = img.getOriginalFilename();
+            // S3 URL 생성
+            // 예시: 파일 이름을 기준으로 경로를 생성 (디렉토리 없이 URL 생성)
+            String imgUrl = "https://" + bucket + ".s3.amazonaws.com/" + imgName;
+
+            // 메타데이터 설정
+            ObjectMetadata metadata = new ObjectMetadata();
+            metadata.setContentType(img.getContentType());
+            metadata.setContentLength(img.getSize());
+
+            // 파일 S3에 업로드
+            amazonS3Client.putObject(bucket, imgName, img.getInputStream(), metadata);
+
+            // 업로드 후 접근 가능한 URL 생성
+            return amazonS3Client.getUrl(bucket, imgName).toString();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            // 예외 시 null 또는 적절한 값 반환
+            return null;
+        }
+    }
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceService.java
@@ -1,0 +1,9 @@
+package com.likelion.moamoa.domain.reference.service;
+
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceReq;
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceRes;
+
+public interface ReferenceService {
+    // 래퍼런스 저장
+    SaveReferenceRes saveReference(Long folderId, SaveReferenceReq saveReferenceReq);
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceServiceImpl.java
@@ -1,0 +1,60 @@
+package com.likelion.moamoa.domain.reference.service;
+
+import com.likelion.moamoa.domain.folder.entity.Folder;
+import com.likelion.moamoa.domain.folder.exception.NotFoundFolderException;
+import com.likelion.moamoa.domain.folder.repository.FolderRepository;
+import com.likelion.moamoa.domain.reference.entity.Reference;
+import com.likelion.moamoa.domain.reference.repository.ReferenceRepository;
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceReq;
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceRes;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+@Service
+@RequiredArgsConstructor
+public class ReferenceServiceImpl implements ReferenceService {
+
+    private final FolderRepository folderRepository;
+    private final ReferenceRepository referenceRepository;
+
+    private final ImageService imageService;
+
+    // 래퍼런스 저장
+    @Override
+    public SaveReferenceRes saveReference(
+            Long folderId,
+            @ModelAttribute SaveReferenceReq saveReferenceReq
+            /*
+            스프링에서 `폼(form)` 데이터나 `multipart/form-data` 요청을 받을 때 사용
+            HTTP 요청의 파라미터(name, description 등) 를 자동으로 DTO 객체에 바인딩해주는 어노테이션
+            주로 form-data, query string, multipart/form-data 요청에서 사용
+            내부적으로는 @RequestParam과 동일한 방식으로 동작하지만, 객체 단위로 데이터를 자동으로 매핑
+           */
+    ) {
+        // folerId -> folder 확인
+        Folder folder = folderRepository.findById(folderId)
+                .orElseThrow(NotFoundFolderException::new);
+
+        // s3에 저장된 이미지 url 받아오기
+        String url = imageService.uploadImageToS3(saveReferenceReq.getImg());
+
+        // reference 저장
+        Reference reference = Reference.builder()
+                .folder(folder)
+                .name(saveReferenceReq.getName())
+                .description(saveReferenceReq.getDescription())
+                .imgUrl(url)
+                .build();
+
+        Reference saveReference = referenceRepository.save(reference);
+
+        return new SaveReferenceRes(
+                saveReference.getFolder().getFolderId(),
+                saveReference.getId(),
+                saveReference.getName(),
+                saveReference.getDescription(),
+                saveReference.getImgUrl()
+        );
+    }
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/controller/ReferenceController.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/controller/ReferenceController.java
@@ -1,0 +1,35 @@
+package com.likelion.moamoa.domain.reference.web.controller;
+
+import com.likelion.moamoa.domain.folder.web.dto.CreateFolderReq;
+import com.likelion.moamoa.domain.folder.web.dto.CreateFolderRes;
+import com.likelion.moamoa.domain.folder.web.dto.FolderSummeryRes;
+import com.likelion.moamoa.domain.reference.service.ReferenceService;
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceReq;
+import com.likelion.moamoa.domain.reference.web.dto.SaveReferenceRes;
+import com.likelion.moamoa.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/folder/{folderId}/reference")
+@RequiredArgsConstructor
+public class ReferenceController {
+    // 의존성 부여
+    private final ReferenceService referenceService;
+
+    // 사진 저장
+    @PostMapping
+    public ResponseEntity<SuccessResponse<?>> SaveReference(
+            @PathVariable Long folderId,
+            @ModelAttribute @Valid SaveReferenceReq saveReferenceReq
+    ) {
+        SaveReferenceRes saveReferenceRes = referenceService.saveReference(folderId, saveReferenceReq);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.ok(saveReferenceRes));
+    }
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceReq.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceReq.java
@@ -1,0 +1,32 @@
+package com.likelion.moamoa.domain.reference.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class SaveReferenceReq {
+
+    @NotBlank(message = "사진 이름은 필수값입니다.")
+    private String name;
+
+    @NotEmpty(message = "사진 설명은 필수값입니다.")
+    private String description;
+
+    @NotNull(message = "사진은 필수입니다.")
+    private MultipartFile img;
+
+    /*
+        | 어노테이션   | null 허용 | "" 허용 | " " 허용 |
+        | ----------- | --------- | ------- | -------- |
+        | `@NotNull`  | ❌       | ✅     | ✅       |
+        | `@NotEmpty` | ❌       | ❌     | ✅       |
+        | `@NotBlank` | ❌       | ❌     | ❌       |
+    */
+}

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceRes.java
@@ -1,0 +1,10 @@
+package com.likelion.moamoa.domain.reference.web.dto;
+
+public record SaveReferenceRes(
+        Long folderId,
+        Long referenceId,
+        String name,
+        String description,
+        String imgUrl
+) {
+}


### PR DESCRIPTION
## #⃣ 연관된 이슈
<!-- > ex) #이슈번호, #이슈번호 -->
- #14 

<hr>

## 📝작업 내용
<!-- > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 사진 이름, 사진 설명, 사진 저장 가능
  <img width="440" alt="image" src="https://github.com/user-attachments/assets/0fb4d2d2-c55d-42ad-903d-8a57f5be5b5e" />
  <img width="508" alt="image" src="https://github.com/user-attachments/assets/5a6d5e2f-88bf-4f43-9d90-209effa5ef54" />

<hr>

## ✍️ 배운점
- 이미지 파일을 같이 보낼 때는 `JSON` 형식이 아니라 `multipart/form-data` 형식을 사용해야 한다.
  - `multipart/form-data` : HTML form에서 파일을 전송할 수 있게 만든 표준 형식
  - 이미지, PDF, 엑셀 파일 등 파일과 텍스트를 함께 전송할 수 있는 유일한 Content-Type

<br>

- `@RequestBody`는 `JSON`만 처리할 수 있기 때문에, 파일 업로드에는 사용할 수 없다.
  - 파일과 텍스트를 함께 받으려면 `@ModelAttribute` 또는 `@RequestParam`을 사용해야 한다.
  -  `@ModelAttribute` : 스프링에서 주로 `form-data`, `query string`, `multipart/form-data` 요청을 받을 때 사용
    - HTTP 요청의 파라미터를 자동으로 DTO 객체(여기서는 `SaveReferenceReq`)에 바인딩해주는 어노테이션
    - 내부적으로는 `@RequestParam`과 동일한 방식으로 동작하지만, 객체 단위로 데이터를 자동으로 매핑

<br>

- Postman에서 form-data로 전송 시 key 값은 **DTO 필드명과 정확히 일치**해야 한다.
  ![image](https://github.com/user-attachments/assets/ab7914d9-e5fc-436b-a817-3fc7094c038f)
  - 여기서 key값은 `name`, `description`, `img`이다.


<br>
 
- DTO에 `MultipartFile`을 받을 경우, 반드시 `@Setter`가 있어야 바인딩이 정상적으로 작동
  - 스프링은 다음 순서로 동작
    1. `SaveReferenceReq` 객체를 새로 생성
    2. 들어온 `multipart/form-data`를 보고 `setter 메서드` 호출해서 값을 바인딩
    3. 값이 다 바인딩 되면 `@Valid`로 유효성 검사 수행
  - 이런 순서로 동작하기 때문에 `@Setter`가 없으면 정상적으로 바인딩 **X**

<br>

- `@NotNull`, `@NotEmpty`,  `@NotBlank` **차이점**
  - `@NotNull` : null만 허용 X, 빈 문자열(`""`)이나 공백 문자열(`" "`)은 허용 O
  - `@NotEmpty` : null과 빈 문자열(`""`)은 허용 X, 공백 문자열(`" "`)은 허용 O
  - `@NotBlank` : null, 빈 문자열(`""`), 공백 문자열(`" "`) 모두 허용 X

| 어노테이션   | null 허용 | "" 허용 | " " 허용 |
| ----------- | -------- | ------- | -------- |
| `@NotNull`  | ❌       | ✅     | ✅       |
| `@NotEmpty` | ❌       | ❌     | ✅       |
| `@NotBlank` | ❌       | ❌     | ❌       |


