### PR TITLE
:sparkles: feat: 래퍼런스 삭제 기능 추가

### DIFF
--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/entitiy/Chat.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/entitiy/Chat.java
@@ -20,8 +20,6 @@ public class Chat extends BaseEntity {
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
 
-    private String sessionUuid;
-
     @Enumerated(EnumType.STRING)
     private MessageRole messageRole;
 

--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/repository/ChatRepository.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/repository/ChatRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface ChatRepository extends JpaRepository<Chat, Long> {
 
-    List<Chat> findBySessionUuidOrderByCreatedAtAsc(String sessionUuid);
+    List<Chat> findByRecommendation_RecommendationIdOrderByCreatedAtAsc(Long recommendationId);
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/service/ChatService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/service/ChatService.java
@@ -10,6 +10,6 @@ public interface ChatService {
     ChatMessageRes sendMessage(ChatMessageReq chatMessageReq);
 
     // 메서드 시그니처는 동일
-    List<ChatMessageRes> getChatHistory(String sessionId);
+    List<ChatMessageRes> getChatHistory(Long recommendation);
 
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/controller/ChatController.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/controller/ChatController.java
@@ -34,10 +34,11 @@ public class ChatController {
     }
 
 
-    @GetMapping("/history/{sessionId}")
-    public ResponseEntity<SuccessResponse<List<ChatMessageRes>>> getChatHistory(@PathVariable("sessionId") String sessionId) {
-
-        List<ChatMessageRes> chatHistory = chatService.getChatHistory(sessionId);
+    @GetMapping("/history/{recommendationId}")
+    public ResponseEntity<SuccessResponse<List<ChatMessageRes>>> getChatHistory(
+            @PathVariable("recommendationId") Long recommendationId
+    ) {
+        List<ChatMessageRes> chatHistory = chatService.getChatHistory(recommendationId);
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.ok(chatHistory));

--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/dto/ChatMessageReq.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/dto/ChatMessageReq.java
@@ -11,8 +11,6 @@ public class ChatMessageReq {
 
     private Long recommendationId;
 
-    private String sessionId;
-
     private String message;
 
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/dto/ChatMessageRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/chat/web/dto/ChatMessageRes.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 @Builder
 public record ChatMessageRes(
         Long chatId,
-        String sessionId,
+        Long recommendationId,
         String message,
         MessageRole messageRole,
         LocalDateTime createdAt

--- a/moamoa/src/main/java/com/likelion/moamoa/common/question/entity/Recommendation.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/question/entity/Recommendation.java
@@ -3,34 +3,24 @@ package com.likelion.moamoa.common.question.entity;
 import com.likelion.moamoa.domain.auth.entity.User;
 import com.likelion.moamoa.domain.reference.entity.Reference;
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Entity
 @Getter
 @Setter
 @NoArgsConstructor
+@Builder
+@AllArgsConstructor
 public class Recommendation {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "RECOMMENDATION_ID")
     private Long recommendationId;
 
     @Column(columnDefinition = "TEXT")
     private String question;
 
     @OneToOne
-    @JoinColumn(name = "reference_id")
+    @JoinColumn(name = "REFERENCE_ID") // FK 가짐
     private Reference reference;
-
-    @OneToOne
-    @JoinColumn(name = "User_id")
-    private User user;
-
-    public Recommendation(String question, Reference reference) {
-        this.question = question;
-        this.reference = reference;
-    }
 
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/common/question/entity/Recommendation.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/question/entity/Recommendation.java
@@ -1,9 +1,13 @@
 package com.likelion.moamoa.common.question.entity;
 
+import com.likelion.moamoa.common.chat.entitiy.Chat;
 import com.likelion.moamoa.domain.auth.entity.User;
 import com.likelion.moamoa.domain.reference.entity.Reference;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -22,5 +26,8 @@ public class Recommendation {
     @OneToOne
     @JoinColumn(name = "REFERENCE_ID") // FK 가짐
     private Reference reference;
+
+    @OneToMany(mappedBy = "recommendation", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Chat> chatList = new ArrayList<>();
 
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/common/question/service/RecommendationServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/question/service/RecommendationServiceImpl.java
@@ -36,24 +36,26 @@ public class RecommendationServiceImpl implements RecommendationService {
 
         String question = openAiService.getRecommendationQuestion(imgUrl, description);
 
-        Recommendation recommendation = new Recommendation(question, reference);
-        Recommendation saved = recommendationRepository.save(recommendation);
-
         Folder folder = reference.getFolder();
         User user = folder.getUser();
 
-
-        return CreateQuestionRes.builder()
-                .recommendationId(saved.getRecommendationId())
-                .userId(user.getUserId())
-                .folderId(folder.getFolderId())
-                .referenceId(reference.getReferenceId())
-                .question(saved.getQuestion())
+        Recommendation recommendation = Recommendation
+                .builder()
+                .question(question)
+                .reference(reference)
                 .build();
+
+        Recommendation saved = recommendationRepository.save(recommendation);
+
+
+        return new CreateQuestionRes(
+                saved.getRecommendationId(),
+                saved.getQuestion(),
+                saved.getReference().getFolder().getUser().getUserId(),
+                saved.getReference().getFolder().getFolderId(),
+                saved.getReference().getReferenceId()
+        );
     }
-
-
-
-    }
+}
 
 

--- a/moamoa/src/main/java/com/likelion/moamoa/common/question/web/dto/CreateQuestionReq.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/question/web/dto/CreateQuestionReq.java
@@ -2,10 +2,11 @@ package com.likelion.moamoa.common.question.web.dto;
 
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
-@Setter
+@NoArgsConstructor
 public class CreateQuestionReq {
     @NotNull
     private Long referenceId;

--- a/moamoa/src/main/java/com/likelion/moamoa/common/question/web/dto/CreateQuestionRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/common/question/web/dto/CreateQuestionRes.java
@@ -5,9 +5,9 @@ import lombok.Builder;
 @Builder
 public record CreateQuestionRes(
         Long recommendationId,
+        String question,
         Long userId,
         Long folderId,
-        Long referenceId,
-        String question
+        Long referenceId
 ) {
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/auth/entity/User.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/auth/entity/User.java
@@ -15,8 +15,10 @@ public class User {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "USER_ID")
     private Long userId;
+
     @Column(name = "LOGIN_ID")
     private String loginId;
+
     @Column(name = "PASSWORD")
     private String password;
 

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/auth/repository/UserRepository.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/auth/repository/UserRepository.java
@@ -2,10 +2,12 @@ package com.likelion.moamoa.domain.auth.repository;
 
 import com.likelion.moamoa.domain.auth.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 // User 엔티티 DB 연동, 회원 가입 중복 검사
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByLoginId(String loginId);

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/auth/service/UserServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/auth/service/UserServiceImpl.java
@@ -54,7 +54,9 @@ public class UserServiceImpl implements UserService {
         }
 
         // 반환
-        return new SigninUserRes(user.getLoginId());
+        return new SigninUserRes(
+                user.getUserId(),
+                user.getLoginId());
     }
 
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/auth/web/dto/SigninUserRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/auth/web/dto/SigninUserRes.java
@@ -1,4 +1,6 @@
 package com.likelion.moamoa.domain.auth.web.dto;
 
-public record SigninUserRes(String loginId) {
+public record SigninUserRes(
+        Long userId,
+        String loginId) {
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/entity/Folder.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/entity/Folder.java
@@ -1,8 +1,13 @@
 package com.likelion.moamoa.domain.folder.entity;
 
+import com.likelion.moamoa.domain.reference.entity.Reference;
 import jakarta.persistence.*;
 import lombok.*;
 import com.likelion.moamoa.domain.auth.entity.User;
+
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @Setter
@@ -25,4 +30,13 @@ public class Folder {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "USER_ID", nullable = false)
     private User user;
+
+    @OneToMany(mappedBy = "folder", cascade = CascadeType.REMOVE, orphanRemoval = true, fetch = FetchType.LAZY)
+    private List<Reference> references = new ArrayList<>();
+
+    // 편의 메서드 -> 폴더가 삭제 될 때, 폴더 안에 사진들을 삭제 하기 위함
+//    public void removeReference(Reference reference) {
+//        references.remove(reference);
+//        reference.setFolder(null);
+//    }
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/repository/FolderRepository.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/repository/FolderRepository.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Repository;
 import java.util.List;
 
 @Repository
-public interface FolderRepository extends JpaRepository< Folder, Long> {
+public interface FolderRepository extends JpaRepository<Folder, Long> {
     // 폴더 중복
     boolean existsByFolderNameAndUser_UserId(String folderName, Long userUserId);
     // userId로 폴더 조회
     List<Folder> findAllByUser_UserId(Long userId);
+    // userId에 몇개의 폴더가 있는지 확인
+    Long countFolderByUser_UserId(Long userId);
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/service/FolderService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/service/FolderService.java
@@ -2,14 +2,14 @@ package com.likelion.moamoa.domain.folder.service;
 
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderReq;
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderRes;
-import com.likelion.moamoa.domain.folder.web.dto.FolderSummeryRes;
+import com.likelion.moamoa.domain.folder.web.dto.FolderSummaryRes;
 
 public interface FolderService {
     // 폴더 생성
     CreateFolderRes createFolder(Long userId, CreateFolderReq createFolderReq);
 
     // 폴더 전체 조회
-    FolderSummeryRes getAllByFolder(Long userId);
+    FolderSummaryRes getAllByFolder(Long userId);
 
     // 폴더 삭제
     void deleteOneFolder(Long userId, Long folderid);

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/service/FolderServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/service/FolderServiceImpl.java
@@ -9,10 +9,16 @@ import com.likelion.moamoa.domain.folder.exception.NotFoundUserException;
 import com.likelion.moamoa.domain.folder.repository.FolderRepository;
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderReq;
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderRes;
-import com.likelion.moamoa.domain.folder.web.dto.FolderSummeryRes;
+import com.likelion.moamoa.domain.folder.web.dto.FolderSummaryRes;
+import com.likelion.moamoa.domain.folder.web.dto.FolderSummaryRes.FolderSummary;
+import com.likelion.moamoa.domain.reference.entity.Reference;
+import com.likelion.moamoa.domain.reference.service.ImageService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
@@ -21,28 +27,30 @@ public class FolderServiceImpl implements FolderService {
     private final FolderRepository folderRepository;
     private final UserRepository userRepository;
 
+    private final ImageService imageService;
+
     // 폴더 생성
     @Override
     public CreateFolderRes createFolder(Long userId, CreateFolderReq createFolderReq) {
-        // 0. userId -> User Entity 찾기
+        // userId -> User Entity 찾기
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
 
-        // 1. createFolderReq -> Folder Entity 생성
         // 폴더 중복 예외
         if(folderRepository.existsByFolderNameAndUser_UserId(createFolderReq.getFolderName(), userId)) {
             throw new DuplicateFolderNameException();
         }
+
         Folder folder = Folder.builder()
                 .folderName(createFolderReq.getFolderName())
-                .folderOrder(folderRepository.count()) // 0번부터 시작
+                .folderOrder(folderRepository.countFolderByUser_UserId(userId)) // 0번부터 시작
                 .user(user)
                 .build();
 
-        // 2. Folder Entity DB 저장
+        // Folder Entity DB 저장
         Folder saveFolder = folderRepository.save(folder);
 
-        // 3. Folder Entity -> CreateFolderRes로 변환
+        // Folder Entity -> CreateFolderRes로 변환
         return new CreateFolderRes(
                 saveFolder.getUser().getUserId(),
                 saveFolder.getFolderId(),
@@ -53,27 +61,31 @@ public class FolderServiceImpl implements FolderService {
 
     // 폴더 전체 조회
     @Override
-    @Transactional
-    public FolderSummeryRes getAllByFolder(Long userId) {
-        // 1. userId -> User Entity 찾기
+    public FolderSummaryRes getAllByFolder(Long userId) {
+        // userId -> User 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(NotFoundUserException::new);
-        // 2. Folder Entity DB 조회
-        return new FolderSummeryRes(
-                folderRepository.findAllByUser_UserId(userId).stream()
-                        .map(folder -> new FolderSummeryRes.FolderSummery(
-                                folder.getFolderId(),
-                                folder.getFolderName(),
-                                folder.getFolderOrder()
-                        ))
-                        .collect(Collectors.toList())
-        );
+
+        List<Folder> folders = folderRepository.findAllByUser_UserId(userId);
+        List<FolderSummary> folderSummaryList = new ArrayList<>();
+
+        for (Folder folder : folders) {
+            FolderSummary folderSummary = new FolderSummary(
+                    folder.getFolderId(),
+                    folder.getFolderName(),
+                    folder.getFolderOrder()
+            );
+            folderSummaryList.add(folderSummary);
+        }
+
+        return new FolderSummaryRes(user.getUserId(), folderSummaryList);
     }
 
     // 폴더 삭제
     @Override
-    public void deleteOneFolder(Long userId, Long folderid) {
-        Folder folder = folderRepository.findById(folderid)
+    @Transactional
+    public void deleteOneFolder(Long userId, Long folderId) {
+        Folder folder = folderRepository.findById(folderId)
                 .orElseThrow(NotFoundFolderException::new);
 
         if (!folder.getUser().getUserId().equals(userId)) {
@@ -81,12 +93,16 @@ public class FolderServiceImpl implements FolderService {
         }
 
         // 폴더 삭제하면 모두 앞당기기
-        long orderValue = folder.getFolderOrder();
+        Long orderValue = folder.getFolderOrder();
         folderRepository.findAllByUser_UserId(userId).stream()
                 .filter(f -> f.getFolderOrder() > orderValue)
                 .forEach(f -> f.setFolderOrder(f.getFolderOrder() - 1));
 
+        // 폴더 안에 있는 사진들 S3에서 삭제하기
+        for (Reference ref : folder.getReferences()) {
+            imageService.deleteImageFromS3(ref.getImgUrl());
+        }
+
         folderRepository.delete(folder);
     }
-
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/controller/FolderController.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/controller/FolderController.java
@@ -3,7 +3,7 @@ package com.likelion.moamoa.domain.folder.web.controller;
 import com.likelion.moamoa.domain.folder.service.FolderService;
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderReq;
 import com.likelion.moamoa.domain.folder.web.dto.CreateFolderRes;
-import com.likelion.moamoa.domain.folder.web.dto.FolderSummeryRes;
+import com.likelion.moamoa.domain.folder.web.dto.FolderSummaryRes;
 import com.likelion.moamoa.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,7 +33,7 @@ public class FolderController {
     // 폴더 전체 조회
     @GetMapping
     public ResponseEntity<SuccessResponse<?>> getAllByFolder(@PathVariable Long userId) {
-        FolderSummeryRes folderSummeryRes = folderService.getAllByFolder(userId);
+        FolderSummaryRes folderSummeryRes = folderService.getAllByFolder(userId);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/dto/FolderSummaryRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/folder/web/dto/FolderSummaryRes.java
@@ -2,8 +2,11 @@ package com.likelion.moamoa.domain.folder.web.dto;
 
 import java.util.List;
 
-public record FolderSummeryRes(List<FolderSummery> folderSummeryList) {
-    public record FolderSummery(
+public record FolderSummaryRes(
+        Long userId,
+        List<FolderSummary> folderSummeryList
+) {
+    public record FolderSummary(
             Long folderId,
             String folderName,
             Long folderOrder

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
@@ -37,10 +37,4 @@ public class Reference {
     @OneToOne(mappedBy = "reference", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private Recommendation recommendation;
 
-    public void deleteRecommendation(Recommendation recommendation) {
-        Reference reference = recommendation.getReference(); // 양방향 관계일 경우
-        if (reference != null) {
-            reference.setRecommendation(null); // orphanRemoval = true이면 Recommendation 삭제됨
-        }
-    }
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/entity/Reference.java
@@ -1,9 +1,10 @@
 package com.likelion.moamoa.domain.reference.entity;
 
-import com.likelion.moamoa.domain.auth.entity.User;
+import com.likelion.moamoa.common.question.entity.Recommendation;
 import com.likelion.moamoa.domain.folder.entity.Folder;
 import jakarta.persistence.*;
 import lombok.*;
+
 
 @Entity
 @Getter
@@ -33,4 +34,13 @@ public class Reference {
     @JoinColumn(name = "FOLDER_ID", nullable = false)
     private Folder folder;
 
+    @OneToOne(mappedBy = "reference", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private Recommendation recommendation;
+
+    public void deleteRecommendation(Recommendation recommendation) {
+        Reference reference = recommendation.getReference(); // 양방향 관계일 경우
+        if (reference != null) {
+            reference.setRecommendation(null); // orphanRemoval = true이면 Recommendation 삭제됨
+        }
+    }
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/repository/ReferenceRepository.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/repository/ReferenceRepository.java
@@ -4,8 +4,16 @@ import com.likelion.moamoa.domain.reference.entity.Reference;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface ReferenceRepository extends JpaRepository<Reference, Long> {
     // 파일명 중복되는지 안되는지
     boolean existsByName(String name);
+
+    // folderId로 폴더 안에 속한 래퍼런스들 조회
+    List<Reference> findAllByFolder_FolderId(Long folderId);
+
+    // folderId로 폴더 안에 속한 래퍼런스의 개수 반환
+    Long countReferenceByFolder_FolderId(Long folderId);
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageService.java
@@ -5,4 +5,7 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ImageService {
     // s3에 저장하여 이미지 주소로 반환
     String uploadImageToS3(MultipartFile img);
+
+    // s3에서 이미지 삭제
+    void deleteImageFromS3(String imgUrl);
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageServiceImpl.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ImageServiceImpl.java
@@ -44,4 +44,16 @@ public class ImageServiceImpl implements ImageService {
             return null;
         }
     }
+
+    @Override
+    public void deleteImageFromS3(String imgUrl) {
+        try {
+            // https://[bucket].s3.amazonaws.com/[filename] 에서 파일명 추출
+            String fileName = imgUrl.substring(imgUrl.lastIndexOf("/") + 1);
+
+            amazonS3Client.deleteObject(bucket, fileName);
+        } catch (Exception e) {
+            e.printStackTrace(); // 로그 출력 (실무에선 Logger 권장)
+        }
+    }
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceService.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/service/ReferenceService.java
@@ -12,4 +12,6 @@ public interface ReferenceService {
     ReferenceSummaryRes getAllReference(Long folderId);
     // 래퍼런스 단일 조회
     ReferenceDetailRes getReference(Long folderId, Long referenceId);
+    // 래퍼런스 삭제
+    void deleteReference(Long folderId, Long referenceId);
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/controller/ReferenceController.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/controller/ReferenceController.java
@@ -56,4 +56,17 @@ public class ReferenceController {
                 .status(HttpStatus.OK)
                 .body(SuccessResponse.ok(referenceDetailRes));
     }
+
+    // 래퍼런스 삭제
+    @DeleteMapping("/{referenceId}")
+    public ResponseEntity<SuccessResponse<?>> deleteReference(
+            @PathVariable Long folderId,
+            @PathVariable Long referenceId
+    ) {
+        referenceService.deleteReference(folderId, referenceId);
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(SuccessResponse.empty());
+    }
 }

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/ReferenceSummaryRes.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/ReferenceSummaryRes.java
@@ -2,7 +2,10 @@ package com.likelion.moamoa.domain.reference.web.dto;
 
 import java.util.List;
 
-public record ReferenceSummaryRes(List<ReferenceSummary> referenceSummaryList) {
+public record ReferenceSummaryRes(
+        Long folderId,
+        List<ReferenceSummary> referenceSummaryList
+) {
     public record ReferenceSummary(
             Long referenceId,
             Long referenceOrder,

--- a/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceReq.java
+++ b/moamoa/src/main/java/com/likelion/moamoa/domain/reference/web/dto/SaveReferenceReq.java
@@ -1,7 +1,6 @@
 package com.likelion.moamoa.domain.reference.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,7 +15,7 @@ public class SaveReferenceReq {
     @NotBlank(message = "사진 이름은 필수값입니다.")
     private String name;
 
-    @NotEmpty(message = "사진 설명은 필수값입니다.")
+    @NotBlank(message = "사진 설명은 필수값입니다.")
     private String description;
 
     @NotNull(message = "사진은 필수입니다.")


### PR DESCRIPTION
## #⃣연관된 이슈
<!-- > ex) #이슈번호, -->
- #11 
- #17 

## 📝작업 내용
<!-- > 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능) -->
- 래퍼런스 삭제할 때, ai가 날린 질문도 같이 삭제할 수 있도록 삭제 기능 추가
- 래퍼런스 삭제할 때, ai와 대화한 기록들도 같이 삭제할 수 있도록 기능 **수정**
- 폴더 삭제도, 안에 있는 래퍼런스들 전부 삭제 될 수 있도록 코드 변경
- 그 외 이상한 기능들 수정
  - 로그인 하고 난 후, `loginId` 뿐만 아니라 `userId`도 반환될 수 있도록 수정
  - 폴더를 생성할 때, user 상관없이 전체 폴더를 대상으로 `folderOrder`가 매겨지는거 수정
    - ex) user1, user2가 있음, user1이 f1을 만들고, f2를 만들고, user2가 f3를 만들고, 다시 user1이 f4를 만들면
      - f1는 0번, f2는 1번, f3는 2번, f4는 3번이 된다. 
      - (수정된 버전) -> f1은 0번, f2는 1번, f4는 2번으로, f2는 0번이 되어야 된다.
  - 폴더를 조회하면, user 상관없이 모든 폴더가 조회되는 기능 수정 -> 해당 유저에 있는 폴더들만 조회될 수 있도록 함.
  - 래퍼런스를 조회하면, folder 상관없이 모든 래퍼런스가 조회되는 기능 수정 -> 해당 폴더에 있는 래퍼런스들만 조회될 수 있도록 함.